### PR TITLE
chore: Add pipeline that prevents forbidden usernames

### DIFF
--- a/edx_filters_pipelines/auth/pipelines/registration.py
+++ b/edx_filters_pipelines/auth/pipelines/registration.py
@@ -19,9 +19,7 @@ class PreventForbiddenUsernameRegistration(PipelineStep):
                 "pipeline": [
                     "edx_filters_pipelines.auth.pipelines.registration.PreventForbiddenUsernameRegistration"
                 ],
-                "extra_config": {
-                    "forbidden_usernames": ["admin", "test", "staff"]
-                },
+                "forbidden_usernames": ['admin', 'test', 'staff'],
                 "fail_silently": False
             }
         }
@@ -47,7 +45,7 @@ class PreventForbiddenUsernameRegistration(PipelineStep):
             )
             raise StudentRegistrationRequested.PreventRegistration(
                 message=(
-                    f"Username '{username}' contains a forbidden word: '{forbidden_match}'. "
+                    f"Usernames can't include words that could be mistaken for course roles. "
                     "Please choose a different username."
                 ),
                 status_code=403

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,3 +3,5 @@
 
 setuptools
 openedx-filters
+pytest
+pytest-cov

--- a/tests/test_edx-filters-pipelines.py
+++ b/tests/test_edx-filters-pipelines.py
@@ -3,10 +3,19 @@ Tests for edx-filters-pipelines.py.
 """
 
 import pytest
+from edx_filters_pipelines.auth.pipelines.registration import PreventForbiddenUsernameRegistration
+from openedx_filters.learning.filters import StudentRegistrationRequested
 
+def test_username_blocked():
+    step = PreventForbiddenUsernameRegistration(
+        'org.openedx.learning.student.registration.requested.v1',
+        'edx_filters_pipelines.auth.pipelines.registration.PreventForbiddenUsernameRegistration',
+        forbidden_usernames= ["admin", "staff"]
+    )
+    
+    form_data = {"username": "admin123"}
+    
+    with pytest.raises(StudentRegistrationRequested.PreventRegistration) as exc_info:
+        step.run_filter(form_data=form_data)
 
-@pytest.mark.skip(reason="Placeholder to allow pytest to succeed before real tests are in place.")
-def test_placeholder():
-    """
-    TODO: Delete this test once there are real tests.
-    """
+    assert "admin" in str(exc_info.value)


### PR DESCRIPTION
This PR introduces a custom pipeline that prevents user registration when the creating username contains any configured forbidden substrings.