### PR TITLE
fix: Return form data from pipeline PreventForbiddenUsernameRegistration

### DIFF
--- a/edx_filters_pipelines/__init__.py
+++ b/edx_filters_pipelines/__init__.py
@@ -2,4 +2,4 @@
 A Python package that defines and manages custom filter pipelines for use with edx-filters.
 """
 
-__version__ = '0.1.0'
+__version__ = '1.0.1'

--- a/edx_filters_pipelines/auth/pipelines/registration.py
+++ b/edx_filters_pipelines/auth/pipelines/registration.py
@@ -51,3 +51,4 @@ class PreventForbiddenUsernameRegistration(PipelineStep):
                 status_code=403,
                 error_code='forbidden-username'
             )
+        return form_data


### PR DESCRIPTION
This PR fixes the PreventForbiddenUsernameRegistration pipeline step to correctly return a dictionary containing form_data