### PR TITLE
chore: Add GitHub Actions workflow for Pytest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+name: Pytest
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements/test.in
+
+    - name: Run tests with pytest
+      run: |
+        pytest --maxfail=1 --disable-warnings -q

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements/test.in
+        pip install -e .
 
     - name: Run tests with pytest
       run: |


### PR DESCRIPTION
This pull request introduces automated testing for the project using GitHub Actions. The new workflow runs tests with pytest on both Python 3.11 and 3.12 whenever code is pushed or a pull request is opened.

Continuous integration setup:

* Added a `.github/workflows/main.yml` workflow that installs dependencies and runs pytest on Python 3.11 and 3.12 for all pushes and pull requests.