### PR TITLE
fix: Add management command monitoring pipeline

### DIFF
--- a/edx_filters_pipelines/management/__init__.py
+++ b/edx_filters_pipelines/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management command filter pipeline integrations."""

--- a/edx_filters_pipelines/management/pipelines/__init__.py
+++ b/edx_filters_pipelines/management/pipelines/__init__.py
@@ -1,0 +1,1 @@
+"""Pipeline steps for management command integrations."""

--- a/edx_filters_pipelines/management/pipelines/monitoring.py
+++ b/edx_filters_pipelines/management/pipelines/monitoring.py
@@ -33,10 +33,14 @@ def monitor_management_command(command_name, service_variant, trace_name=DEFAULT
         with function_trace(trace_name):
             yield
         status = 'success'
-    except BaseException as exc:
+    except SystemExit as exc:
         set_custom_attribute('management_command.exception_class', exc.__class__.__name__)
-        if isinstance(exc, SystemExit):
-            set_custom_attribute('management_command.exit_code', exc.code)
+        set_custom_attribute('management_command.exit_code', exc.code)
+        if exc.code in (0, None):
+            status = 'success'
+        raise
+    except Exception as exc:
+        set_custom_attribute('management_command.exception_class', exc.__class__.__name__)
         raise
     finally:
         set_custom_attribute('management_command.status', status)

--- a/edx_filters_pipelines/management/pipelines/monitoring.py
+++ b/edx_filters_pipelines/management/pipelines/monitoring.py
@@ -44,12 +44,12 @@ def monitor_management_command(command_name, service_variant, trace_name=DEFAULT
             yield
         status = 'success'
     except SystemExit as exc:
-        set_custom_attribute('management_command.exception_class', exc.__class__.__name__)
-        set_custom_attribute('management_command.exit_code', exc.code)
-        set_custom_attribute('management_command.exception_message', str(exc))
         if exc.code in (0, None):
             status = 'success'
         else:
+            set_custom_attribute('management_command.exception_class', exc.__class__.__name__)
+            set_custom_attribute('management_command.exit_code', exc.code)
+            set_custom_attribute('management_command.exception_message', str(exc))
             log.exception(
                 'Management command failed: %s service_variant=%s transaction_name=%s exit_code=%s error=%s',
                 command_name,

--- a/edx_filters_pipelines/management/pipelines/monitoring.py
+++ b/edx_filters_pipelines/management/pipelines/monitoring.py
@@ -5,44 +5,60 @@ import os
 import time
 from contextlib import contextmanager, nullcontext
 
-from edx_django_utils.monitoring import function_trace, set_custom_attribute, set_monitoring_transaction_name
+from edx_django_utils.monitoring import (
+    function_trace,
+    set_custom_attribute,
+    set_monitoring_transaction_name,
+)
 from openedx_filters import PipelineStep
 
 from edx_filters_pipelines.waffle import ENABLE_MANAGEMENT_COMMAND_MONITORING
 
 log = logging.getLogger(__name__)
 
-DEFAULT_TRACE_NAME = 'django.management.command'
+DEFAULT_OPERATION_NAME = 'django.management.command'
 
 
 @contextmanager
-def monitor_management_command(command_name, service_variant, trace_name=DEFAULT_TRACE_NAME):
+def monitor_management_command(
+    command_name,
+    service_variant,
+    operation_name=DEFAULT_OPERATION_NAME,
+):
     """
-    Wrap a management command execution with Datadog monitoring metadata and a start log entry.
-    """
-    transaction_name = f'{service_variant}.management.{command_name}'
+    Wrap a management command execution with monitoring metadata and logging.
 
-    set_monitoring_transaction_name(transaction_name)
+    The operation name identifies the type of operation, while the resource
+    name identifies the specific management command being executed.
+    """
+    resource_name = f'{service_variant}.management.{command_name}'
+
+    set_monitoring_transaction_name(resource_name)
     set_custom_attribute('management_command.name', command_name)
     set_custom_attribute('management_command.service_variant', service_variant)
-    set_custom_attribute('management_command.transaction_name', transaction_name)
+
     github_run_url = os.getenv('EDX_MC_GITHUB_RUN_URL', '').strip()
     if github_run_url:
         set_custom_attribute('management_command.github_run_url', github_run_url)
+
     log.info(
-        'Starting management command: %s service_variant=%s transaction_name=%s',
+        'Starting management command: %s service_variant=%s '
+        'operation_name=%s resource_name=%s',
         command_name,
         service_variant,
-        transaction_name,
+        operation_name,
+        resource_name,
     )
 
     start_time = time.monotonic()
     status = 'failure'
 
     try:
-        with function_trace(trace_name):
+        with function_trace(resource_name, operation_name=operation_name):
             yield
+
         status = 'success'
+
     except SystemExit as exc:
         if exc.code in (0, None):
             status = 'success'
@@ -51,35 +67,43 @@ def monitor_management_command(command_name, service_variant, trace_name=DEFAULT
             set_custom_attribute('management_command.exit_code', exc.code)
             set_custom_attribute('management_command.exception_message', str(exc))
             log.exception(
-                'Management command failed: %s service_variant=%s transaction_name=%s exit_code=%s error=%s',
+                'Management command failed: %s service_variant=%s '
+                'operation_name=%s resource_name=%s exit_code=%s error=%s',
                 command_name,
                 service_variant,
-                transaction_name,
+                operation_name,
+                resource_name,
                 exc.code,
                 exc,
             )
         raise
+
     except Exception as exc:
         set_custom_attribute('management_command.exception_class', exc.__class__.__name__)
         set_custom_attribute('management_command.exception_message', str(exc))
         log.exception(
-            'Management command failed: %s service_variant=%s transaction_name=%s exception_class=%s error=%s',
+            'Management command failed: %s service_variant=%s '
+            'operation_name=%s resource_name=%s exception_class=%s error=%s',
             command_name,
             service_variant,
-            transaction_name,
+            operation_name,
+            resource_name,
             exc.__class__.__name__,
             exc,
         )
         raise
+
     finally:
         duration = time.monotonic() - start_time
         set_custom_attribute('management_command.status', status)
         set_custom_attribute('management_command.duration_seconds', duration)
         log.info(
-            'Finished management command: %s service_variant=%s transaction_name=%s status=%s duration_seconds=%s',
+            'Finished management command: %s service_variant=%s '
+            'operation_name=%s resource_name=%s status=%s duration_seconds=%s',
             command_name,
             service_variant,
-            transaction_name,
+            operation_name,
+            resource_name,
             status,
             duration,
         )
@@ -87,14 +111,19 @@ def monitor_management_command(command_name, service_variant, trace_name=DEFAULT
 
 class ManagementCommandMonitoringPipelineStep(PipelineStep):
     """
-    Add Datadog monitoring around Django management command execution.
+    Add monitoring around Django management command execution.
     """
 
-    def run_filter(self, command_contextmanager, command_name, service_variant):  # pylint: disable=arguments-differ
+    def run_filter(
+        self,
+        command_contextmanager,
+        command_name,
+        service_variant,
+    ):  # pylint: disable=arguments-differ
         """
         Return a wrapped context manager that applies monitoring when enabled.
         """
-        trace_name = self.extra_config.get('trace_name', DEFAULT_TRACE_NAME)
+        operation_name = self.extra_config.get('operation_name', DEFAULT_OPERATION_NAME)
 
         @contextmanager
         def wrapped_contextmanager():
@@ -102,10 +131,15 @@ class ManagementCommandMonitoringPipelineStep(PipelineStep):
 
             try:
                 if ENABLE_MANAGEMENT_COMMAND_MONITORING.is_enabled():
-                    monitor_contextmanager = monitor_management_command(command_name, service_variant, trace_name)
+                    monitor_contextmanager = monitor_management_command(
+                        command_name,
+                        service_variant,
+                        operation_name,
+                    )
             except Exception:  # pylint: disable=broad-except
                 log.exception(
-                    'Failed to initialize management command monitoring for %s; continuing without monitoring.',
+                    'Failed to initialize management command monitoring '
+                    'for %s; continuing without monitoring.',
                     command_name,
                 )
 

--- a/edx_filters_pipelines/management/pipelines/monitoring.py
+++ b/edx_filters_pipelines/management/pipelines/monitoring.py
@@ -4,7 +4,6 @@ import logging
 import time
 from contextlib import contextmanager, nullcontext
 
-import django
 from edx_django_utils.monitoring import function_trace, set_custom_attribute, set_monitoring_transaction_name
 from openedx_filters import PipelineStep
 
@@ -17,7 +16,9 @@ DEFAULT_TRACE_NAME = 'django.management.command'
 
 @contextmanager
 def monitor_management_command(command_name, service_variant, trace_name=DEFAULT_TRACE_NAME):
-    """Wrap a management command execution with Datadog monitoring metadata."""
+    """
+    Wrap a management command execution with Datadog monitoring metadata.
+    """
     transaction_name = f'{service_variant}.management.{command_name}'
 
     set_monitoring_transaction_name(transaction_name)
@@ -43,17 +44,20 @@ def monitor_management_command(command_name, service_variant, trace_name=DEFAULT
 
 
 class ManagementCommandMonitoringPipelineStep(PipelineStep):
-    """Add Datadog monitoring around Django management command execution."""
+    """
+    Add Datadog monitoring around Django management command execution.
+    """
 
     def run_filter(self, command_name, service_variant, command_runner):  # pylint: disable=arguments-differ
-        """Return a wrapped command runner that applies monitoring when enabled."""
+        """
+        Return a wrapped command runner that applies monitoring when enabled.
+        """
         trace_name = self.extra_config.get('trace_name', DEFAULT_TRACE_NAME)
 
         def wrapped_runner():
             monitor_context = nullcontext()
 
             try:
-                django.setup()
                 if ENABLE_MANAGEMENT_COMMAND_MONITORING.is_enabled():
                     monitor_context = monitor_management_command(command_name, service_variant, trace_name)
             except Exception:  # pylint: disable=broad-except

--- a/edx_filters_pipelines/management/pipelines/monitoring.py
+++ b/edx_filters_pipelines/management/pipelines/monitoring.py
@@ -52,13 +52,14 @@ class ManagementCommandMonitoringPipelineStep(PipelineStep):
     Add Datadog monitoring around Django management command execution.
     """
 
-    def run_filter(self, command_name, service_variant, command_runner):  # pylint: disable=arguments-differ
+    def run_filter(self, command_contextmanager, command_name, service_variant):  # pylint: disable=arguments-differ
         """
-        Return a wrapped command runner that applies monitoring when enabled.
+        Return a wrapped context manager that applies monitoring when enabled.
         """
         trace_name = self.extra_config.get('trace_name', DEFAULT_TRACE_NAME)
 
-        def wrapped_runner():
+        @contextmanager
+        def wrapped_contextmanager():
             monitor_context = nullcontext()
 
             try:
@@ -70,11 +71,12 @@ class ManagementCommandMonitoringPipelineStep(PipelineStep):
                     command_name,
                 )
 
-            with monitor_context:
-                return command_runner()
+            with command_contextmanager:
+                with monitor_context:
+                    yield
 
         return {
+            'command_contextmanager': wrapped_contextmanager(),
             'command_name': command_name,
             'service_variant': service_variant,
-            'command_runner': wrapped_runner,
         }

--- a/edx_filters_pipelines/management/pipelines/monitoring.py
+++ b/edx_filters_pipelines/management/pipelines/monitoring.py
@@ -60,19 +60,19 @@ class ManagementCommandMonitoringPipelineStep(PipelineStep):
 
         @contextmanager
         def wrapped_contextmanager():
-            monitor_context = nullcontext()
+            monitor_contextmanager = nullcontext()
 
             try:
                 if ENABLE_MANAGEMENT_COMMAND_MONITORING.is_enabled():
-                    monitor_context = monitor_management_command(command_name, service_variant, trace_name)
+                    monitor_contextmanager = monitor_management_command(command_name, service_variant, trace_name)
             except Exception:  # pylint: disable=broad-except
                 log.exception(
                     'Failed to initialize management command monitoring for %s; continuing without monitoring.',
                     command_name,
                 )
 
-            with command_contextmanager:
-                with monitor_context:
+            with monitor_contextmanager:
+                with command_contextmanager:
                     yield
 
         return {

--- a/edx_filters_pipelines/management/pipelines/monitoring.py
+++ b/edx_filters_pipelines/management/pipelines/monitoring.py
@@ -15,18 +15,14 @@ log = logging.getLogger(__name__)
 DEFAULT_TRACE_NAME = 'django.management.command'
 
 GITHUB_METADATA_ATTRIBUTE_MAP = {
-    'EDX_MC_JOB_NAME': 'management_command.job_name',
-    'EDX_MC_GROUP_NAME': 'management_command.group_name',
-    'EDX_MC_DESCRIPTION': 'management_command.description',
     'EDX_MC_GITHUB_RUN_URL': 'management_command.github_run_url',
-    'EDX_MC_GITHUB_WORKFLOW_URL': 'management_command.github_workflow_url',
-    'EDX_MC_CONFIG_PATH': 'management_command.config_path',
-    'EDX_MC_CONFIG_URL': 'management_command.config_url',
 }
 
 
 def _set_management_command_metadata_from_environment():
-    """Attach workflow metadata to traces when available from automation environments."""
+    """
+    Attach workflow metadata to traces when available from automation environments.
+    """
     metadata_attributes = {
         attribute_name: value
         for env_name, attribute_name in GITHUB_METADATA_ATTRIBUTE_MAP.items()

--- a/edx_filters_pipelines/management/pipelines/monitoring.py
+++ b/edx_filters_pipelines/management/pipelines/monitoring.py
@@ -17,7 +17,7 @@ DEFAULT_TRACE_NAME = 'django.management.command'
 @contextmanager
 def monitor_management_command(command_name, service_variant, trace_name=DEFAULT_TRACE_NAME):
     """
-    Wrap a management command execution with Datadog monitoring metadata.
+    Wrap a management command execution with Datadog monitoring metadata and a start log entry.
     """
     transaction_name = f'{service_variant}.management.{command_name}'
 
@@ -25,6 +25,12 @@ def monitor_management_command(command_name, service_variant, trace_name=DEFAULT
     set_custom_attribute('management_command.name', command_name)
     set_custom_attribute('management_command.service_variant', service_variant)
     set_custom_attribute('management_command.transaction_name', transaction_name)
+    log.info(
+        'Starting management command: %s service_variant=%s transaction_name=%s',
+        command_name,
+        service_variant,
+        transaction_name,
+    )
 
     start_time = time.monotonic()
     status = 'failure'
@@ -36,15 +42,43 @@ def monitor_management_command(command_name, service_variant, trace_name=DEFAULT
     except SystemExit as exc:
         set_custom_attribute('management_command.exception_class', exc.__class__.__name__)
         set_custom_attribute('management_command.exit_code', exc.code)
+        set_custom_attribute('management_command.exception_message', str(exc))
         if exc.code in (0, None):
             status = 'success'
+        else:
+            log.exception(
+                'Management command failed: %s service_variant=%s transaction_name=%s exit_code=%s error=%s',
+                command_name,
+                service_variant,
+                transaction_name,
+                exc.code,
+                exc,
+            )
         raise
     except Exception as exc:
         set_custom_attribute('management_command.exception_class', exc.__class__.__name__)
+        set_custom_attribute('management_command.exception_message', str(exc))
+        log.exception(
+            'Management command failed: %s service_variant=%s transaction_name=%s exception_class=%s error=%s',
+            command_name,
+            service_variant,
+            transaction_name,
+            exc.__class__.__name__,
+            exc,
+        )
         raise
     finally:
+        duration = time.monotonic() - start_time
         set_custom_attribute('management_command.status', status)
-        set_custom_attribute('management_command.duration_seconds', time.monotonic() - start_time)
+        set_custom_attribute('management_command.duration_seconds', duration)
+        log.info(
+            'Finished management command: %s service_variant=%s transaction_name=%s status=%s duration_seconds=%s',
+            command_name,
+            service_variant,
+            transaction_name,
+            status,
+            duration,
+        )
 
 
 class ManagementCommandMonitoringPipelineStep(PipelineStep):

--- a/edx_filters_pipelines/management/pipelines/monitoring.py
+++ b/edx_filters_pipelines/management/pipelines/monitoring.py
@@ -14,24 +14,6 @@ log = logging.getLogger(__name__)
 
 DEFAULT_TRACE_NAME = 'django.management.command'
 
-GITHUB_METADATA_ATTRIBUTE_MAP = {
-    'EDX_MC_GITHUB_RUN_URL': 'management_command.github_run_url',
-}
-
-
-def _set_management_command_metadata_from_environment():
-    """
-    Attach workflow metadata to traces when available from automation environments.
-    """
-    metadata_attributes = {
-        attribute_name: value
-        for env_name, attribute_name in GITHUB_METADATA_ATTRIBUTE_MAP.items()
-        if (value := os.getenv(env_name, '').strip())
-    }
-
-    for attribute_name, value in metadata_attributes.items():
-        set_custom_attribute(attribute_name, value)
-
 
 @contextmanager
 def monitor_management_command(command_name, service_variant, trace_name=DEFAULT_TRACE_NAME):
@@ -44,7 +26,9 @@ def monitor_management_command(command_name, service_variant, trace_name=DEFAULT
     set_custom_attribute('management_command.name', command_name)
     set_custom_attribute('management_command.service_variant', service_variant)
     set_custom_attribute('management_command.transaction_name', transaction_name)
-    _set_management_command_metadata_from_environment()
+    github_run_url = os.getenv('EDX_MC_GITHUB_RUN_URL', '').strip()
+    if github_run_url:
+        set_custom_attribute('management_command.github_run_url', github_run_url)
     log.info(
         'Starting management command: %s service_variant=%s transaction_name=%s',
         command_name,

--- a/edx_filters_pipelines/management/pipelines/monitoring.py
+++ b/edx_filters_pipelines/management/pipelines/monitoring.py
@@ -1,6 +1,7 @@
 """Pipeline steps for management command observability."""
 
 import logging
+import os
 import time
 from contextlib import contextmanager, nullcontext
 
@@ -12,6 +13,28 @@ from edx_filters_pipelines.waffle import ENABLE_MANAGEMENT_COMMAND_MONITORING
 log = logging.getLogger(__name__)
 
 DEFAULT_TRACE_NAME = 'django.management.command'
+
+GITHUB_METADATA_ATTRIBUTE_MAP = {
+    'EDX_MC_JOB_NAME': 'management_command.job_name',
+    'EDX_MC_GROUP_NAME': 'management_command.group_name',
+    'EDX_MC_DESCRIPTION': 'management_command.description',
+    'EDX_MC_GITHUB_RUN_URL': 'management_command.github_run_url',
+    'EDX_MC_GITHUB_WORKFLOW_URL': 'management_command.github_workflow_url',
+    'EDX_MC_CONFIG_PATH': 'management_command.config_path',
+    'EDX_MC_CONFIG_URL': 'management_command.config_url',
+}
+
+
+def _set_management_command_metadata_from_environment():
+    """Attach workflow metadata to traces when available from automation environments."""
+    metadata_attributes = {
+        attribute_name: value
+        for env_name, attribute_name in GITHUB_METADATA_ATTRIBUTE_MAP.items()
+        if (value := os.getenv(env_name, '').strip())
+    }
+
+    for attribute_name, value in metadata_attributes.items():
+        set_custom_attribute(attribute_name, value)
 
 
 @contextmanager
@@ -25,6 +48,7 @@ def monitor_management_command(command_name, service_variant, trace_name=DEFAULT
     set_custom_attribute('management_command.name', command_name)
     set_custom_attribute('management_command.service_variant', service_variant)
     set_custom_attribute('management_command.transaction_name', transaction_name)
+    _set_management_command_metadata_from_environment()
     log.info(
         'Starting management command: %s service_variant=%s transaction_name=%s',
         command_name,

--- a/edx_filters_pipelines/management/pipelines/monitoring.py
+++ b/edx_filters_pipelines/management/pipelines/monitoring.py
@@ -1,0 +1,72 @@
+"""Pipeline steps for management command observability."""
+
+import logging
+import time
+from contextlib import contextmanager, nullcontext
+
+import django
+from edx_django_utils.monitoring import function_trace, set_custom_attribute, set_monitoring_transaction_name
+from openedx_filters import PipelineStep
+
+from edx_filters_pipelines.waffle import ENABLE_MANAGEMENT_COMMAND_MONITORING
+
+log = logging.getLogger(__name__)
+
+DEFAULT_TRACE_NAME = 'django.management.command'
+
+
+@contextmanager
+def monitor_management_command(command_name, service_variant, trace_name=DEFAULT_TRACE_NAME):
+    """Wrap a management command execution with Datadog monitoring metadata."""
+    transaction_name = f'{service_variant}.management.{command_name}'
+
+    set_monitoring_transaction_name(transaction_name)
+    set_custom_attribute('management_command.name', command_name)
+    set_custom_attribute('management_command.service_variant', service_variant)
+    set_custom_attribute('management_command.transaction_name', transaction_name)
+
+    start_time = time.monotonic()
+    status = 'failure'
+
+    try:
+        with function_trace(trace_name):
+            yield
+        status = 'success'
+    except BaseException as exc:
+        set_custom_attribute('management_command.exception_class', exc.__class__.__name__)
+        if isinstance(exc, SystemExit):
+            set_custom_attribute('management_command.exit_code', exc.code)
+        raise
+    finally:
+        set_custom_attribute('management_command.status', status)
+        set_custom_attribute('management_command.duration_seconds', time.monotonic() - start_time)
+
+
+class ManagementCommandMonitoringPipelineStep(PipelineStep):
+    """Add Datadog monitoring around Django management command execution."""
+
+    def run_filter(self, command_name, service_variant, command_runner, **kwargs):
+        """Return a wrapped command runner that applies monitoring when enabled."""
+        trace_name = self.extra_config.get('trace_name', DEFAULT_TRACE_NAME)
+
+        def wrapped_runner():
+            monitor_context = nullcontext()
+
+            try:
+                django.setup()
+                if ENABLE_MANAGEMENT_COMMAND_MONITORING.is_enabled():
+                    monitor_context = monitor_management_command(command_name, service_variant, trace_name)
+            except Exception:  # pylint: disable=broad-except
+                log.exception(
+                    'Failed to initialize management command monitoring for %s; continuing without monitoring.',
+                    command_name,
+                )
+
+            with monitor_context:
+                return command_runner()
+
+        return {
+            'command_name': command_name,
+            'service_variant': service_variant,
+            'command_runner': wrapped_runner,
+        }

--- a/edx_filters_pipelines/management/pipelines/monitoring.py
+++ b/edx_filters_pipelines/management/pipelines/monitoring.py
@@ -45,7 +45,7 @@ def monitor_management_command(command_name, service_variant, trace_name=DEFAULT
 class ManagementCommandMonitoringPipelineStep(PipelineStep):
     """Add Datadog monitoring around Django management command execution."""
 
-    def run_filter(self, command_name, service_variant, command_runner, **kwargs):
+    def run_filter(self, command_name, service_variant, command_runner):  # pylint: disable=arguments-differ
         """Return a wrapped command runner that applies monitoring when enabled."""
         trace_name = self.extra_config.get('trace_name', DEFAULT_TRACE_NAME)
 

--- a/edx_filters_pipelines/waffle.py
+++ b/edx_filters_pipelines/waffle.py
@@ -1,7 +1,7 @@
 """
-waffle flags used in the filters_pipelines app.
+Feature toggles used in the filters_pipelines app.
 """
-from edx_toggles.toggles import WaffleFlag
+from edx_toggles.toggles import SettingToggle, WaffleFlag
 
 WAFFLE_NAMESPACE = 'filters_pipelines'
 
@@ -15,14 +15,15 @@ WAFFLE_NAMESPACE = 'filters_pipelines'
 # .. toggle_warning: When the flag is ON, recaptcha validation is enabled on registration.
 ENABLE_RECAPTCHA_VALIDATION = WaffleFlag(f'{WAFFLE_NAMESPACE}.enable_registration_recaptcha_validation', __name__)
 
-# .. toggle_name: filters_pipelines.enable_management_command_monitoring
-# .. toggle_implementation: WaffleFlag
+# .. toggle_name: FILTERS_PIPELINES_ENABLE_MANAGEMENT_COMMAND_MONITORING
+# .. toggle_implementation: SettingToggle
 # .. toggle_default: False
-# .. toggle_description: Waffle flag to enable Datadog monitoring for Django management commands.
+# .. toggle_description: Settings toggle to enable Datadog monitoring for Django management commands.
 # .. toggle_use_cases: opt_in
 # .. toggle_creation_date: 2026-03-26
 # .. toggle_target_removal_date: None because this is a long-term feature
-# .. toggle_warning: When the flag is ON, management command execution is wrapped with Datadog monitoring.
-ENABLE_MANAGEMENT_COMMAND_MONITORING = WaffleFlag(
-	f'{WAFFLE_NAMESPACE}.enable_management_command_monitoring', __name__
+# .. toggle_warning: When the setting is True, management command execution is wrapped with Datadog monitoring.
+ENABLE_MANAGEMENT_COMMAND_MONITORING = SettingToggle(
+	'FILTERS_PIPELINES_ENABLE_MANAGEMENT_COMMAND_MONITORING',
+	default=False,
 )

--- a/edx_filters_pipelines/waffle.py
+++ b/edx_filters_pipelines/waffle.py
@@ -24,6 +24,6 @@ ENABLE_RECAPTCHA_VALIDATION = WaffleFlag(f'{WAFFLE_NAMESPACE}.enable_registratio
 # .. toggle_target_removal_date: None because this is a long-term feature
 # .. toggle_warning: When the setting is True, management command execution is wrapped with Datadog monitoring.
 ENABLE_MANAGEMENT_COMMAND_MONITORING = SettingToggle(
-	'FILTERS_PIPELINES_ENABLE_MANAGEMENT_COMMAND_MONITORING',
-	default=False,
+    'FILTERS_PIPELINES_ENABLE_MANAGEMENT_COMMAND_MONITORING',
+    default=False,
 )

--- a/edx_filters_pipelines/waffle.py
+++ b/edx_filters_pipelines/waffle.py
@@ -14,3 +14,15 @@ WAFFLE_NAMESPACE = 'filters_pipelines'
 # .. toggle_target_removal_date: None because this is a long-term feature
 # .. toggle_warning: When the flag is ON, recaptcha validation is enabled on registration.
 ENABLE_RECAPTCHA_VALIDATION = WaffleFlag(f'{WAFFLE_NAMESPACE}.enable_registration_recaptcha_validation', __name__)
+
+# .. toggle_name: filters_pipelines.enable_management_command_monitoring
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to enable Datadog monitoring for Django management commands.
+# .. toggle_use_cases: opt_in
+# .. toggle_creation_date: 2026-03-26
+# .. toggle_target_removal_date: None because this is a long-term feature
+# .. toggle_warning: When the flag is ON, management command execution is wrapped with Datadog monitoring.
+ENABLE_MANAGEMENT_COMMAND_MONITORING = WaffleFlag(
+	f'{WAFFLE_NAMESPACE}.enable_management_command_monitoring', __name__
+)

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -5,6 +5,7 @@
 
 pytest
 pytest-cov                # pytest extension for code coverage statistics
+pytest-mock               # pytest plugin providing mocker fixture
 edx-lint
 pylint-celery
 setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -196,6 +196,8 @@ pytest-cov==6.2.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
+pytest-mock
+    # via -r requirements/test.in
 python-slugify==8.0.4
     # via
     #   -r requirements/base.txt

--- a/tests/test_edx-filters-pipelines.py
+++ b/tests/test_edx-filters-pipelines.py
@@ -8,7 +8,10 @@ import pytest
 from openedx_filters.learning.filters import StudentRegistrationRequested
 
 from edx_filters_pipelines.auth.pipelines.registration import PreventForbiddenUsernameRegistration
-from edx_filters_pipelines.management.pipelines.monitoring import ManagementCommandMonitoringPipelineStep
+from edx_filters_pipelines.management.pipelines.monitoring import (
+    ManagementCommandMonitoringPipelineStep,
+    monitor_management_command,
+)
 
 
 def test_username_blocked():
@@ -99,3 +102,41 @@ def test_management_command_monitoring_step_uses_configured_trace_name(mocker):
     step.run_filter('collectstatic', 'cms', command_runner)['command_runner']()
 
     function_trace.assert_called_once_with('custom.management.trace')
+
+
+def test_monitor_management_command_system_exit_zero_is_success(mocker):
+    mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.function_trace',
+        return_value=nullcontext(),
+    )
+    set_custom_attribute = mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.set_custom_attribute'
+    )
+    mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.set_monitoring_transaction_name')
+
+    with pytest.raises(SystemExit):
+        with monitor_management_command('migrate', 'lms'):
+            raise SystemExit(0)
+
+    set_custom_attribute.assert_any_call('management_command.exit_code', 0)
+    set_custom_attribute.assert_any_call('management_command.status', 'success')
+
+
+def test_monitor_management_command_keyboard_interrupt_not_recorded_as_exception_class(mocker):
+    mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.function_trace',
+        return_value=nullcontext(),
+    )
+    set_custom_attribute = mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.set_custom_attribute'
+    )
+    mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.set_monitoring_transaction_name')
+
+    with pytest.raises(KeyboardInterrupt):
+        with monitor_management_command('migrate', 'lms'):
+            raise KeyboardInterrupt()
+
+    assert ('management_command.exception_class', 'KeyboardInterrupt') not in [
+        call.args for call in set_custom_attribute.call_args_list
+    ]
+    set_custom_attribute.assert_any_call('management_command.status', 'failure')

--- a/tests/test_edx-filters-pipelines.py
+++ b/tests/test_edx-filters-pipelines.py
@@ -32,7 +32,6 @@ def test_management_command_monitoring_step_disabled(mocker):
         'edx_filters_pipelines.management.pipelines.monitoring.ManagementCommandMonitoringPipelineStep',
     )
     command_runner = mocker.Mock(return_value='ok')
-    django_setup = mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.django.setup')
     toggle = mocker.patch(
         'edx_filters_pipelines.management.pipelines.monitoring.ENABLE_MANAGEMENT_COMMAND_MONITORING.is_enabled',
         return_value=False,
@@ -44,7 +43,6 @@ def test_management_command_monitoring_step_disabled(mocker):
     assert result['command_name'] == 'migrate'
     assert result['service_variant'] == 'lms'
     assert result['command_runner']() == 'ok'
-    django_setup.assert_called_once()
     toggle.assert_called_once()
     command_runner.assert_called_once()
 
@@ -55,7 +53,6 @@ def test_management_command_monitoring_step_enabled(mocker):
         'edx_filters_pipelines.management.pipelines.monitoring.ManagementCommandMonitoringPipelineStep',
     )
     command_runner = mocker.Mock(return_value='ok')
-    mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.django.setup')
     mocker.patch(
         'edx_filters_pipelines.management.pipelines.monitoring.ENABLE_MANAGEMENT_COMMAND_MONITORING.is_enabled',
         return_value=True,
@@ -88,7 +85,6 @@ def test_management_command_monitoring_step_uses_configured_trace_name(mocker):
         trace_name='custom.management.trace',
     )
     command_runner = mocker.Mock(return_value=None)
-    mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.django.setup')
     mocker.patch(
         'edx_filters_pipelines.management.pipelines.monitoring.ENABLE_MANAGEMENT_COMMAND_MONITORING.is_enabled',
         return_value=True,

--- a/tests/test_edx-filters-pipelines.py
+++ b/tests/test_edx-filters-pipelines.py
@@ -155,14 +155,15 @@ def test_monitor_management_command_logs_failure(mocker):
         'lms',
         'lms.management.migrate',
     )
-    log.exception.assert_called_once_with(
+    assert log.exception.call_count == 1
+    assert log.exception.call_args.args[:5] == (
         'Management command failed: %s service_variant=%s transaction_name=%s exception_class=%s error=%s',
         'migrate',
         'lms',
         'lms.management.migrate',
         'RuntimeError',
-        RuntimeError('boom'),
     )
+    assert str(log.exception.call_args.args[5]) == 'boom'
     set_custom_attribute.assert_any_call('management_command.status', 'failure')
     set_custom_attribute.assert_any_call('management_command.duration_seconds', 5.0)
     set_custom_attribute.assert_any_call('management_command.exception_message', 'boom')

--- a/tests/test_edx-filters-pipelines.py
+++ b/tests/test_edx-filters-pipelines.py
@@ -162,7 +162,7 @@ def test_monitor_management_command_logs_failure(mocker):
         'lms.management.migrate',
     )
     assert log.exception.call_count == 1
-    assert log.exception.call_args.args[:5] == (
+    assert log.exception.call_args.args[:6] == (
         'Management command failed: %s service_variant=%s '
         'operation_name=%s resource_name=%s exception_class=%s error=%s',
         'migrate',
@@ -171,7 +171,7 @@ def test_monitor_management_command_logs_failure(mocker):
         'lms.management.migrate',
         'RuntimeError',
     )
-    assert str(log.exception.call_args.args[5]) == 'boom'
+    assert str(log.exception.call_args.args[6]) == 'boom'
     set_custom_attribute.assert_any_call('management_command.status', 'failure')
     set_custom_attribute.assert_any_call('management_command.duration_seconds', 5.0)
     set_custom_attribute.assert_any_call('management_command.exception_message', 'boom')

--- a/tests/test_edx-filters-pipelines.py
+++ b/tests/test_edx-filters-pipelines.py
@@ -177,7 +177,14 @@ def test_monitor_management_command_logs_failure(mocker):
     )
 
 
-def test_monitor_management_command_sets_github_run_url_attribute(mocker):
+@pytest.mark.parametrize(
+    'run_url',
+    [
+        'https://github.com/edx/edx-internal/actions/runs/123',
+        'https://github.com/edx/edx-internal/actions/runs/999',
+    ],
+)
+def test_monitor_management_command_sets_github_run_url_attribute(mocker, run_url):
     mocker.patch(
         'edx_filters_pipelines.management.pipelines.monitoring.function_trace',
         return_value=nullcontext(),
@@ -189,7 +196,7 @@ def test_monitor_management_command_sets_github_run_url_attribute(mocker):
     mocker.patch.dict(
         'os.environ',
         {
-            'EDX_MC_GITHUB_RUN_URL': 'https://github.com/edx/edx-internal/actions/runs/123',
+            'EDX_MC_GITHUB_RUN_URL': run_url,
         },
         clear=False,
     )
@@ -199,32 +206,7 @@ def test_monitor_management_command_sets_github_run_url_attribute(mocker):
 
     set_custom_attribute.assert_any_call(
         'management_command.github_run_url',
-        'https://github.com/edx/edx-internal/actions/runs/123',
-    )
-
-
-def test_monitor_management_command_sets_github_run_url_when_present(mocker):
-    mocker.patch(
-        'edx_filters_pipelines.management.pipelines.monitoring.function_trace',
-        return_value=nullcontext(),
-    )
-    set_custom_attribute = mocker.patch(
-        'edx_filters_pipelines.management.pipelines.monitoring.set_custom_attribute'
-    )
-    mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.set_monitoring_transaction_name')
-
-    mocker.patch.dict(
-        'os.environ',
-        {'EDX_MC_GITHUB_RUN_URL': 'https://github.com/edx/edx-internal/actions/runs/999'},
-        clear=False,
-    )
-
-    with monitor_management_command('migrate', 'lms'):
-        pass
-
-    set_custom_attribute.assert_any_call(
-        'management_command.github_run_url',
-        'https://github.com/edx/edx-internal/actions/runs/999',
+        run_url,
     )
 
 
@@ -254,7 +236,8 @@ def test_monitor_management_command_ignores_blank_github_run_url(mocker):
 @pytest.mark.parametrize(
     'raised_exception, expected_status, expected_exit_code, exception_class_recorded',
     [
-        pytest.param(SystemExit(0), 'success', 0, True, id='system-exit-zero'),
+        pytest.param(SystemExit(0), 'success', None, False, id='system-exit-zero'),
+        pytest.param(SystemExit(1), 'failure', 1, True, id='system-exit-nonzero'),
         pytest.param(KeyboardInterrupt(), 'failure', None, False, id='keyboard-interrupt'),
     ],
 )
@@ -281,6 +264,10 @@ def test_monitor_management_command_exception_handling(
     if expected_exit_code is not None:
         assert exc_info.value.code == expected_exit_code
         set_custom_attribute.assert_any_call('management_command.exit_code', expected_exit_code)
+    else:
+        assert ('management_command.exit_code',) not in [
+            call.args[:1] for call in set_custom_attribute.call_args_list
+        ]
 
     if exception_class_recorded:
         set_custom_attribute.assert_any_call('management_command.exception_message', str(raised_exception))

--- a/tests/test_edx-filters-pipelines.py
+++ b/tests/test_edx-filters-pipelines.py
@@ -9,7 +9,6 @@ from openedx_filters.learning.filters import StudentRegistrationRequested
 
 from edx_filters_pipelines.auth.pipelines.registration import PreventForbiddenUsernameRegistration
 from edx_filters_pipelines.management.pipelines.monitoring import (
-    GITHUB_METADATA_ATTRIBUTE_MAP,
     ManagementCommandMonitoringPipelineStep,
     monitor_management_command,
 )
@@ -204,7 +203,7 @@ def test_monitor_management_command_sets_github_run_url_attribute(mocker):
     )
 
 
-def test_monitor_management_command_metadata_mapping_uses_all_defined_keys(mocker):
+def test_monitor_management_command_sets_github_run_url_when_present(mocker):
     mocker.patch(
         'edx_filters_pipelines.management.pipelines.monitoring.function_trace',
         return_value=nullcontext(),
@@ -214,20 +213,22 @@ def test_monitor_management_command_metadata_mapping_uses_all_defined_keys(mocke
     )
     mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.set_monitoring_transaction_name')
 
-    metadata_env = {
-        env_name: f'value-for-{env_name.lower()}'
-        for env_name in GITHUB_METADATA_ATTRIBUTE_MAP
-    }
-    mocker.patch.dict('os.environ', metadata_env, clear=False)
+    mocker.patch.dict(
+        'os.environ',
+        {'EDX_MC_GITHUB_RUN_URL': 'https://github.com/edx/edx-internal/actions/runs/999'},
+        clear=False,
+    )
 
     with monitor_management_command('migrate', 'lms'):
         pass
 
-    for env_name, attribute_name in GITHUB_METADATA_ATTRIBUTE_MAP.items():
-        set_custom_attribute.assert_any_call(attribute_name, metadata_env[env_name])
+    set_custom_attribute.assert_any_call(
+        'management_command.github_run_url',
+        'https://github.com/edx/edx-internal/actions/runs/999',
+    )
 
 
-def test_monitor_management_command_metadata_mapping_ignores_blank_values(mocker):
+def test_monitor_management_command_ignores_blank_github_run_url(mocker):
     mocker.patch(
         'edx_filters_pipelines.management.pipelines.monitoring.function_trace',
         return_value=nullcontext(),
@@ -237,11 +238,7 @@ def test_monitor_management_command_metadata_mapping_ignores_blank_values(mocker
     )
     mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.set_monitoring_transaction_name')
 
-    metadata_env = {
-        env_name: '   '
-        for env_name in GITHUB_METADATA_ATTRIBUTE_MAP
-    }
-    mocker.patch.dict('os.environ', metadata_env, clear=False)
+    mocker.patch.dict('os.environ', {'EDX_MC_GITHUB_RUN_URL': '   '}, clear=False)
 
     with monitor_management_command('migrate', 'lms'):
         pass
@@ -251,8 +248,7 @@ def test_monitor_management_command_metadata_mapping_ignores_blank_values(mocker
         for call in set_custom_attribute.call_args_list
         if call.args[0].startswith('management_command.')
     ]
-    for attribute_name in GITHUB_METADATA_ATTRIBUTE_MAP.values():
-        assert attribute_name not in metadata_calls
+    assert 'management_command.github_run_url' not in metadata_calls
 
 
 @pytest.mark.parametrize(

--- a/tests/test_edx-filters-pipelines.py
+++ b/tests/test_edx-filters-pipelines.py
@@ -83,33 +83,37 @@ def test_management_command_monitoring_step_enabled(mocker):
         command_execution()
 
     command_execution.assert_called_once()
-    function_trace.assert_called_once_with('django.management.command')
+    function_trace.assert_called_once_with('lms.management.migrate', operation_name='django.management.command')
     set_transaction_name.assert_called_once_with('lms.management.migrate')
     set_custom_attribute.assert_any_call('management_command.name', 'migrate')
     set_custom_attribute.assert_any_call('management_command.service_variant', 'lms')
     set_custom_attribute.assert_any_call('management_command.duration_seconds', 5.0)
     set_custom_attribute.assert_any_call('management_command.status', 'success')
     log.info.assert_any_call(
-        'Starting management command: %s service_variant=%s transaction_name=%s',
+        'Starting management command: %s service_variant=%s '
+        'operation_name=%s resource_name=%s',
         'migrate',
         'lms',
+        'django.management.command',
         'lms.management.migrate',
     )
     log.info.assert_any_call(
-        'Finished management command: %s service_variant=%s transaction_name=%s status=%s duration_seconds=%s',
+        'Finished management command: %s service_variant=%s '
+        'operation_name=%s resource_name=%s status=%s duration_seconds=%s',
         'migrate',
         'lms',
+        'django.management.command',
         'lms.management.migrate',
         'success',
         5.0,
     )
 
 
-def test_management_command_monitoring_step_uses_configured_trace_name(mocker):
+def test_management_command_monitoring_step_uses_configured_operation_name(mocker):
     step = ManagementCommandMonitoringPipelineStep(
         'org.openedx.platform.management.command.contextmanager.requested.v1',
         'edx_filters_pipelines.management.pipelines.monitoring.ManagementCommandMonitoringPipelineStep',
-        trace_name='custom.management.trace',
+        operation_name='custom.management.operation',
     )
     command_execution = mocker.Mock()
     mocker.patch(
@@ -127,7 +131,7 @@ def test_management_command_monitoring_step_uses_configured_trace_name(mocker):
         command_execution()
 
     command_execution.assert_called_once()
-    function_trace.assert_called_once_with('custom.management.trace')
+    function_trace.assert_called_once_with('cms.management.collectstatic', operation_name='custom.management.operation')
 
 
 def test_monitor_management_command_logs_failure(mocker):
@@ -150,16 +154,20 @@ def test_monitor_management_command_logs_failure(mocker):
             raise RuntimeError('boom')
 
     log.info.assert_any_call(
-        'Starting management command: %s service_variant=%s transaction_name=%s',
+        'Starting management command: %s service_variant=%s '
+        'operation_name=%s resource_name=%s',
         'migrate',
         'lms',
+        'django.management.command',
         'lms.management.migrate',
     )
     assert log.exception.call_count == 1
     assert log.exception.call_args.args[:5] == (
-        'Management command failed: %s service_variant=%s transaction_name=%s exception_class=%s error=%s',
+        'Management command failed: %s service_variant=%s '
+        'operation_name=%s resource_name=%s exception_class=%s error=%s',
         'migrate',
         'lms',
+        'django.management.command',
         'lms.management.migrate',
         'RuntimeError',
     )
@@ -168,9 +176,11 @@ def test_monitor_management_command_logs_failure(mocker):
     set_custom_attribute.assert_any_call('management_command.duration_seconds', 5.0)
     set_custom_attribute.assert_any_call('management_command.exception_message', 'boom')
     log.info.assert_any_call(
-        'Finished management command: %s service_variant=%s transaction_name=%s status=%s duration_seconds=%s',
+        'Finished management command: %s service_variant=%s '
+        'operation_name=%s resource_name=%s status=%s duration_seconds=%s',
         'migrate',
         'lms',
+        'django.management.command',
         'lms.management.migrate',
         'failure',
         5.0,

--- a/tests/test_edx-filters-pipelines.py
+++ b/tests/test_edx-filters-pipelines.py
@@ -104,7 +104,20 @@ def test_management_command_monitoring_step_uses_configured_trace_name(mocker):
     function_trace.assert_called_once_with('custom.management.trace')
 
 
-def test_monitor_management_command_system_exit_zero_is_success(mocker):
+@pytest.mark.parametrize(
+    'raised_exception, expected_status, expected_exit_code, exception_class_recorded',
+    [
+        pytest.param(SystemExit(0), 'success', 0, True, id='system-exit-zero'),
+        pytest.param(KeyboardInterrupt(), 'failure', None, False, id='keyboard-interrupt'),
+    ],
+)
+def test_monitor_management_command_exception_handling(
+    mocker,
+    raised_exception,
+    expected_status,
+    expected_exit_code,
+    exception_class_recorded,
+):
     mocker.patch(
         'edx_filters_pipelines.management.pipelines.monitoring.function_trace',
         return_value=nullcontext(),
@@ -114,29 +127,17 @@ def test_monitor_management_command_system_exit_zero_is_success(mocker):
     )
     mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.set_monitoring_transaction_name')
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(type(raised_exception)) as exc_info:
         with monitor_management_command('migrate', 'lms'):
-            raise SystemExit(0)
+            raise raised_exception
 
-    set_custom_attribute.assert_any_call('management_command.exit_code', 0)
-    set_custom_attribute.assert_any_call('management_command.status', 'success')
+    if expected_exit_code is not None:
+        assert exc_info.value.code == expected_exit_code
+        set_custom_attribute.assert_any_call('management_command.exit_code', expected_exit_code)
 
+    if not exception_class_recorded:
+        assert ('management_command.exception_class', raised_exception.__class__.__name__) not in [
+            call.args for call in set_custom_attribute.call_args_list
+        ]
 
-def test_monitor_management_command_keyboard_interrupt_not_recorded_as_exception_class(mocker):
-    mocker.patch(
-        'edx_filters_pipelines.management.pipelines.monitoring.function_trace',
-        return_value=nullcontext(),
-    )
-    set_custom_attribute = mocker.patch(
-        'edx_filters_pipelines.management.pipelines.monitoring.set_custom_attribute'
-    )
-    mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.set_monitoring_transaction_name')
-
-    with pytest.raises(KeyboardInterrupt):
-        with monitor_management_command('migrate', 'lms'):
-            raise KeyboardInterrupt()
-
-    assert ('management_command.exception_class', 'KeyboardInterrupt') not in [
-        call.args for call in set_custom_attribute.call_args_list
-    ]
-    set_custom_attribute.assert_any_call('management_command.status', 'failure')
+    set_custom_attribute.assert_any_call('management_command.status', expected_status)

--- a/tests/test_edx-filters-pipelines.py
+++ b/tests/test_edx-filters-pipelines.py
@@ -61,6 +61,10 @@ def test_management_command_monitoring_step_enabled(mocker):
         'edx_filters_pipelines.management.pipelines.monitoring.ENABLE_MANAGEMENT_COMMAND_MONITORING.is_enabled',
         return_value=True,
     )
+    mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.time.monotonic',
+        side_effect=[10.0, 15.0],
+    )
     function_trace = mocker.patch(
         'edx_filters_pipelines.management.pipelines.monitoring.function_trace',
         return_value=nullcontext(),
@@ -71,6 +75,7 @@ def test_management_command_monitoring_step_enabled(mocker):
     set_custom_attribute = mocker.patch(
         'edx_filters_pipelines.management.pipelines.monitoring.set_custom_attribute'
     )
+    log = mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.log')
 
     wrapped = step.run_filter(nullcontext(), 'migrate', 'lms')['command_contextmanager']
 
@@ -82,7 +87,22 @@ def test_management_command_monitoring_step_enabled(mocker):
     set_transaction_name.assert_called_once_with('lms.management.migrate')
     set_custom_attribute.assert_any_call('management_command.name', 'migrate')
     set_custom_attribute.assert_any_call('management_command.service_variant', 'lms')
+    set_custom_attribute.assert_any_call('management_command.duration_seconds', 5.0)
     set_custom_attribute.assert_any_call('management_command.status', 'success')
+    log.info.assert_any_call(
+        'Starting management command: %s service_variant=%s transaction_name=%s',
+        'migrate',
+        'lms',
+        'lms.management.migrate',
+    )
+    log.info.assert_any_call(
+        'Finished management command: %s service_variant=%s transaction_name=%s status=%s duration_seconds=%s',
+        'migrate',
+        'lms',
+        'lms.management.migrate',
+        'success',
+        5.0,
+    )
 
 
 def test_management_command_monitoring_step_uses_configured_trace_name(mocker):
@@ -108,6 +128,52 @@ def test_management_command_monitoring_step_uses_configured_trace_name(mocker):
 
     command_execution.assert_called_once()
     function_trace.assert_called_once_with('custom.management.trace')
+
+
+def test_monitor_management_command_logs_failure(mocker):
+    mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.time.monotonic',
+        side_effect=[10.0, 15.0],
+    )
+    mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.function_trace',
+        return_value=nullcontext(),
+    )
+    set_custom_attribute = mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.set_custom_attribute'
+    )
+    log = mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.log')
+    mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.set_monitoring_transaction_name')
+
+    with pytest.raises(RuntimeError):
+        with monitor_management_command('migrate', 'lms'):
+            raise RuntimeError('boom')
+
+    log.info.assert_any_call(
+        'Starting management command: %s service_variant=%s transaction_name=%s',
+        'migrate',
+        'lms',
+        'lms.management.migrate',
+    )
+    log.exception.assert_called_once_with(
+        'Management command failed: %s service_variant=%s transaction_name=%s exception_class=%s error=%s',
+        'migrate',
+        'lms',
+        'lms.management.migrate',
+        'RuntimeError',
+        RuntimeError('boom'),
+    )
+    set_custom_attribute.assert_any_call('management_command.status', 'failure')
+    set_custom_attribute.assert_any_call('management_command.duration_seconds', 5.0)
+    set_custom_attribute.assert_any_call('management_command.exception_message', 'boom')
+    log.info.assert_any_call(
+        'Finished management command: %s service_variant=%s transaction_name=%s status=%s duration_seconds=%s',
+        'migrate',
+        'lms',
+        'lms.management.migrate',
+        'failure',
+        5.0,
+    )
 
 
 @pytest.mark.parametrize(
@@ -140,6 +206,9 @@ def test_monitor_management_command_exception_handling(
     if expected_exit_code is not None:
         assert exc_info.value.code == expected_exit_code
         set_custom_attribute.assert_any_call('management_command.exit_code', expected_exit_code)
+
+    if exception_class_recorded:
+        set_custom_attribute.assert_any_call('management_command.exception_message', str(raised_exception))
 
     if not exception_class_recorded:
         assert ('management_command.exception_class', raised_exception.__class__.__name__) not in [

--- a/tests/test_edx-filters-pipelines.py
+++ b/tests/test_edx-filters-pipelines.py
@@ -178,7 +178,7 @@ def test_monitor_management_command_logs_failure(mocker):
     )
 
 
-def test_monitor_management_command_sets_github_metadata_attributes(mocker):
+def test_monitor_management_command_sets_github_run_url_attribute(mocker):
     mocker.patch(
         'edx_filters_pipelines.management.pipelines.monitoring.function_trace',
         return_value=nullcontext(),
@@ -190,10 +190,7 @@ def test_monitor_management_command_sets_github_metadata_attributes(mocker):
     mocker.patch.dict(
         'os.environ',
         {
-            'EDX_MC_JOB_NAME': 'notify_credentials',
-            'EDX_MC_GROUP_NAME': 'grading',
             'EDX_MC_GITHUB_RUN_URL': 'https://github.com/edx/edx-internal/actions/runs/123',
-            'EDX_MC_CONFIG_PATH': 'argocd/applications/edxapp-lms/management-commands/stage.yml',
         },
         clear=False,
     )
@@ -201,15 +198,9 @@ def test_monitor_management_command_sets_github_metadata_attributes(mocker):
     with monitor_management_command('migrate', 'lms'):
         pass
 
-    set_custom_attribute.assert_any_call('management_command.job_name', 'notify_credentials')
-    set_custom_attribute.assert_any_call('management_command.group_name', 'grading')
     set_custom_attribute.assert_any_call(
         'management_command.github_run_url',
         'https://github.com/edx/edx-internal/actions/runs/123',
-    )
-    set_custom_attribute.assert_any_call(
-        'management_command.config_path',
-        'argocd/applications/edxapp-lms/management-commands/stage.yml',
     )
 
 

--- a/tests/test_edx-filters-pipelines.py
+++ b/tests/test_edx-filters-pipelines.py
@@ -2,9 +2,13 @@
 Tests for edx-filters-pipelines.py.
 """
 
+from contextlib import nullcontext
+
 import pytest
 from openedx_filters.learning.filters import StudentRegistrationRequested
+
 from edx_filters_pipelines.auth.pipelines.registration import PreventForbiddenUsernameRegistration
+from edx_filters_pipelines.management.pipelines.monitoring import ManagementCommandMonitoringPipelineStep
 
 
 def test_username_blocked():
@@ -20,3 +24,82 @@ def test_username_blocked():
         step.run_filter(form_data=form_data)
 
     assert "Usernames can't include words that could be mistaken for course roles." in str(exc_info.value)
+
+
+def test_management_command_monitoring_step_disabled(mocker):
+    step = ManagementCommandMonitoringPipelineStep(
+        'org.openedx.platform.management.command.execute.requested.v1',
+        'edx_filters_pipelines.management.pipelines.monitoring.ManagementCommandMonitoringPipelineStep',
+    )
+    command_runner = mocker.Mock(return_value='ok')
+    django_setup = mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.django.setup')
+    toggle = mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.ENABLE_MANAGEMENT_COMMAND_MONITORING.is_enabled',
+        return_value=False,
+    )
+    mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.function_trace')
+
+    result = step.run_filter('migrate', 'lms', command_runner)
+
+    assert result['command_name'] == 'migrate'
+    assert result['service_variant'] == 'lms'
+    assert result['command_runner']() == 'ok'
+    django_setup.assert_called_once()
+    toggle.assert_called_once()
+    command_runner.assert_called_once()
+
+
+def test_management_command_monitoring_step_enabled(mocker):
+    step = ManagementCommandMonitoringPipelineStep(
+        'org.openedx.platform.management.command.execute.requested.v1',
+        'edx_filters_pipelines.management.pipelines.monitoring.ManagementCommandMonitoringPipelineStep',
+    )
+    command_runner = mocker.Mock(return_value='ok')
+    mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.django.setup')
+    mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.ENABLE_MANAGEMENT_COMMAND_MONITORING.is_enabled',
+        return_value=True,
+    )
+    function_trace = mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.function_trace',
+        return_value=nullcontext(),
+    )
+    set_transaction_name = mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.set_monitoring_transaction_name'
+    )
+    set_custom_attribute = mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.set_custom_attribute'
+    )
+
+    wrapped = step.run_filter('migrate', 'lms', command_runner)['command_runner']
+
+    assert wrapped() == 'ok'
+    function_trace.assert_called_once_with('django.management.command')
+    set_transaction_name.assert_called_once_with('lms.management.migrate')
+    set_custom_attribute.assert_any_call('management_command.name', 'migrate')
+    set_custom_attribute.assert_any_call('management_command.service_variant', 'lms')
+    set_custom_attribute.assert_any_call('management_command.status', 'success')
+
+
+def test_management_command_monitoring_step_uses_configured_trace_name(mocker):
+    step = ManagementCommandMonitoringPipelineStep(
+        'org.openedx.platform.management.command.execute.requested.v1',
+        'edx_filters_pipelines.management.pipelines.monitoring.ManagementCommandMonitoringPipelineStep',
+        trace_name='custom.management.trace',
+    )
+    command_runner = mocker.Mock(return_value=None)
+    mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.django.setup')
+    mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.ENABLE_MANAGEMENT_COMMAND_MONITORING.is_enabled',
+        return_value=True,
+    )
+    function_trace = mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.function_trace',
+        return_value=nullcontext(),
+    )
+    mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.set_monitoring_transaction_name')
+    mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.set_custom_attribute')
+
+    step.run_filter('collectstatic', 'cms', command_runner)['command_runner']()
+
+    function_trace.assert_called_once_with('custom.management.trace')

--- a/tests/test_edx-filters-pipelines.py
+++ b/tests/test_edx-filters-pipelines.py
@@ -9,6 +9,7 @@ from openedx_filters.learning.filters import StudentRegistrationRequested
 
 from edx_filters_pipelines.auth.pipelines.registration import PreventForbiddenUsernameRegistration
 from edx_filters_pipelines.management.pipelines.monitoring import (
+    GITHUB_METADATA_ATTRIBUTE_MAP,
     ManagementCommandMonitoringPipelineStep,
     monitor_management_command,
 )
@@ -175,6 +176,92 @@ def test_monitor_management_command_logs_failure(mocker):
         'failure',
         5.0,
     )
+
+
+def test_monitor_management_command_sets_github_metadata_attributes(mocker):
+    mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.function_trace',
+        return_value=nullcontext(),
+    )
+    set_custom_attribute = mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.set_custom_attribute'
+    )
+    mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.set_monitoring_transaction_name')
+    mocker.patch.dict(
+        'os.environ',
+        {
+            'EDX_MC_JOB_NAME': 'notify_credentials',
+            'EDX_MC_GROUP_NAME': 'grading',
+            'EDX_MC_GITHUB_RUN_URL': 'https://github.com/edx/edx-internal/actions/runs/123',
+            'EDX_MC_CONFIG_PATH': 'argocd/applications/edxapp-lms/management-commands/stage.yml',
+        },
+        clear=False,
+    )
+
+    with monitor_management_command('migrate', 'lms'):
+        pass
+
+    set_custom_attribute.assert_any_call('management_command.job_name', 'notify_credentials')
+    set_custom_attribute.assert_any_call('management_command.group_name', 'grading')
+    set_custom_attribute.assert_any_call(
+        'management_command.github_run_url',
+        'https://github.com/edx/edx-internal/actions/runs/123',
+    )
+    set_custom_attribute.assert_any_call(
+        'management_command.config_path',
+        'argocd/applications/edxapp-lms/management-commands/stage.yml',
+    )
+
+
+def test_monitor_management_command_metadata_mapping_uses_all_defined_keys(mocker):
+    mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.function_trace',
+        return_value=nullcontext(),
+    )
+    set_custom_attribute = mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.set_custom_attribute'
+    )
+    mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.set_monitoring_transaction_name')
+
+    metadata_env = {
+        env_name: f'value-for-{env_name.lower()}'
+        for env_name in GITHUB_METADATA_ATTRIBUTE_MAP
+    }
+    mocker.patch.dict('os.environ', metadata_env, clear=False)
+
+    with monitor_management_command('migrate', 'lms'):
+        pass
+
+    for env_name, attribute_name in GITHUB_METADATA_ATTRIBUTE_MAP.items():
+        set_custom_attribute.assert_any_call(attribute_name, metadata_env[env_name])
+
+
+def test_monitor_management_command_metadata_mapping_ignores_blank_values(mocker):
+    mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.function_trace',
+        return_value=nullcontext(),
+    )
+    set_custom_attribute = mocker.patch(
+        'edx_filters_pipelines.management.pipelines.monitoring.set_custom_attribute'
+    )
+    mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.set_monitoring_transaction_name')
+
+    metadata_env = {
+        env_name: '   '
+        for env_name in GITHUB_METADATA_ATTRIBUTE_MAP
+    }
+    mocker.patch.dict('os.environ', metadata_env, clear=False)
+
+    with monitor_management_command('migrate', 'lms'):
+        pass
+
+    metadata_calls = [
+        call.args[0]
+        for call in set_custom_attribute.call_args_list
+        if call.args[0].startswith('management_command.')
+    ]
+    for attribute_name in GITHUB_METADATA_ATTRIBUTE_MAP.values():
+        assert attribute_name not in metadata_calls
 
 
 @pytest.mark.parametrize(

--- a/tests/test_edx-filters-pipelines.py
+++ b/tests/test_edx-filters-pipelines.py
@@ -31,31 +31,32 @@ def test_username_blocked():
 
 def test_management_command_monitoring_step_disabled(mocker):
     step = ManagementCommandMonitoringPipelineStep(
-        'org.openedx.platform.management.command.execute.requested.v1',
+        'org.openedx.platform.management.command.contextmanager.requested.v1',
         'edx_filters_pipelines.management.pipelines.monitoring.ManagementCommandMonitoringPipelineStep',
     )
-    command_runner = mocker.Mock(return_value='ok')
+    command_execution = mocker.Mock()
     toggle = mocker.patch(
         'edx_filters_pipelines.management.pipelines.monitoring.ENABLE_MANAGEMENT_COMMAND_MONITORING.is_enabled',
         return_value=False,
     )
     mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.function_trace')
 
-    result = step.run_filter('migrate', 'lms', command_runner)
+    result = step.run_filter(nullcontext(), 'migrate', 'lms')
 
     assert result['command_name'] == 'migrate'
     assert result['service_variant'] == 'lms'
-    assert result['command_runner']() == 'ok'
+    with result['command_contextmanager']:
+        command_execution()
     toggle.assert_called_once()
-    command_runner.assert_called_once()
+    command_execution.assert_called_once()
 
 
 def test_management_command_monitoring_step_enabled(mocker):
     step = ManagementCommandMonitoringPipelineStep(
-        'org.openedx.platform.management.command.execute.requested.v1',
+        'org.openedx.platform.management.command.contextmanager.requested.v1',
         'edx_filters_pipelines.management.pipelines.monitoring.ManagementCommandMonitoringPipelineStep',
     )
-    command_runner = mocker.Mock(return_value='ok')
+    command_execution = mocker.Mock()
     mocker.patch(
         'edx_filters_pipelines.management.pipelines.monitoring.ENABLE_MANAGEMENT_COMMAND_MONITORING.is_enabled',
         return_value=True,
@@ -71,9 +72,12 @@ def test_management_command_monitoring_step_enabled(mocker):
         'edx_filters_pipelines.management.pipelines.monitoring.set_custom_attribute'
     )
 
-    wrapped = step.run_filter('migrate', 'lms', command_runner)['command_runner']
+    wrapped = step.run_filter(nullcontext(), 'migrate', 'lms')['command_contextmanager']
 
-    assert wrapped() == 'ok'
+    with wrapped:
+        command_execution()
+
+    command_execution.assert_called_once()
     function_trace.assert_called_once_with('django.management.command')
     set_transaction_name.assert_called_once_with('lms.management.migrate')
     set_custom_attribute.assert_any_call('management_command.name', 'migrate')
@@ -83,11 +87,11 @@ def test_management_command_monitoring_step_enabled(mocker):
 
 def test_management_command_monitoring_step_uses_configured_trace_name(mocker):
     step = ManagementCommandMonitoringPipelineStep(
-        'org.openedx.platform.management.command.execute.requested.v1',
+        'org.openedx.platform.management.command.contextmanager.requested.v1',
         'edx_filters_pipelines.management.pipelines.monitoring.ManagementCommandMonitoringPipelineStep',
         trace_name='custom.management.trace',
     )
-    command_runner = mocker.Mock(return_value=None)
+    command_execution = mocker.Mock()
     mocker.patch(
         'edx_filters_pipelines.management.pipelines.monitoring.ENABLE_MANAGEMENT_COMMAND_MONITORING.is_enabled',
         return_value=True,
@@ -99,8 +103,10 @@ def test_management_command_monitoring_step_uses_configured_trace_name(mocker):
     mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.set_monitoring_transaction_name')
     mocker.patch('edx_filters_pipelines.management.pipelines.monitoring.set_custom_attribute')
 
-    step.run_filter('collectstatic', 'cms', command_runner)['command_runner']()
+    with step.run_filter(nullcontext(), 'collectstatic', 'cms')['command_contextmanager']:
+        command_execution()
 
+    command_execution.assert_called_once()
     function_trace.assert_called_once_with('custom.management.trace')
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ ignore = D101,D200,D203,D212,D215,D404,D405,D406,D407,D408,D409,D410,D411,D412,D
 
 
 [pytest]
-addopts = --cov edx-filters-pipelines --cov-report term-missing --cov-report xml
+addopts = --cov edx_filters_pipelines --cov-report term-missing --cov-report xml
 norecursedirs = .* docs requirements site-packages
 
 [testenv]


### PR DESCRIPTION
### Summary

Adds optional Datadog monitoring for Django management commands via edx_filters_pipelines.

### Changes

- Added management command monitoring with Datadog tracing and custom attributes.
- Added separate operation and resource names for management command traces.
- Added support for the GitHub Actions run URL as a custom monitoring attribute.
- Added command status, duration, and exception metadata.
- Added unit tests for monitoring behavior and operation/resource naming.
- Requires edx-django-utils 8.1.0+ for operation_name support.