### PR TITLE
chore: enable dependabot configuration (AUT-106)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,8 @@ updates:
 
     groups:
       python-minor-and-patch:
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
+
+    labels:
+      - "dependencies"
+      - "python"
+
+    reviewers:
+      - "nakhan-sonata-afk"
+
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "UTC"
+
+    open-pull-requests-limit: 3
+
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+    reviewers:
+      - "nakhan-sonata-afk"
+
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ version: 2
 
 updates:
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "/requirements"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary
Enabled Dependabot configuration for automated dependency updates.

## Changes
- Added .github/dependabot.yml
- Configured updates for:
    - Python (pip dependencies)
    - Github Actions
- Set weekly update schedule
- Added labels and commit message convention

## Schedule
- Runs weekly on Monday at 06:00 UTC (pip)
- Runs weekly on Monday at 06:30 UTC (GitHub Actions)

## Testing
- Verified dependabot.yml syntax
- Configuration follows standard repository setup
- Dependabot will automatically create PRs on scheduled runs

## Impact
- No impact on existing functionality
- Only configuration change

## Jira
[AUT-106](https://2u-internal.atlassian.net/browse/AUT-106)