### PR TITLE
fix: update CI configuration and dependencies for Django 5.2 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Pytest
+name: Python CI
 
 on: [push, pull_request]
 
@@ -7,7 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11"]
+        toxenv: [py311-django42, py311-django52]
 
     steps:
     - name: Checkout repository
@@ -21,9 +22,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements/test.txt
-        pip install -e .
+        pip install tox
 
-    - name: Run tests with pytest
-      run: |
-        pytest --maxfail=1 --disable-warnings -q
+    - name: Run tests with tox
+      env:
+        TOXENV: ${{ matrix.toxenv }}
+      run: tox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
-        toxenv: [py311-django42, py311-django52]
+        include:
+          - python-version: "3.11"
+            toxenv: py311-django42
+          - python-version: "3.11"
+            toxenv: py311-django52
+          - python-version: "3.12"
+            toxenv: py312-django42
+          - python-version: "3.12"
+            toxenv: py312-django52
 
     steps:
     - name: Checkout repository

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,11 @@ Change Log
 Unreleased
 **********
 
-*
+1.1.2 - 2026-08-07
+******************
+
+* Add Django 5.2 tox/CI coverage.
+* Keep tox test deps on compiled requirement pins.
 
 0.1.0 – 2025-08-05
 **********************************************

--- a/edx_filters_pipelines/__init__.py
+++ b/edx_filters_pipelines/__init__.py
@@ -2,4 +2,4 @@
 A Python package that defines and manages custom filter pipelines for use with edx-filters.
 """
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -48,7 +48,7 @@ coverage[toml]==7.10.6
     #   pytest-cov
 dill==0.4.0
     # via pylint
-django==4.2.24
+django<6.0
     # via
     #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -48,7 +48,7 @@ coverage[toml]==7.10.6
     #   pytest-cov
 dill==0.4.0
     # via pylint
-django<6.0
+django==4.2.24
     # via
     #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{312}
+envlist = py311-django{42,52}, quality, docs
 
 [doc8]
 ; D001 = Line too long
@@ -36,6 +36,8 @@ norecursedirs = .* docs requirements site-packages
 
 [testenv]
 deps =
+    django42: Django>=4.2,<5.0
+    django52: Django>=5.2,<5.3
     -r{toxinidir}/requirements/test.txt
 commands =
     pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py311-django{42,52}, quality, docs
+envlist = py{311,312}-django{42,52}, quality, docs
 
 [doc8]
 ; D001 = Line too long
@@ -37,8 +37,9 @@ norecursedirs = .* docs requirements site-packages
 [testenv]
 deps =
     django42: Django>=4.2,<5.0
-    django52: Django>=5.2,<5.3
     -r{toxinidir}/requirements/test.txt
+commands_pre =
+    django52: python -m pip install --upgrade --force-reinstall 'Django>=5.2,<5.3'
 commands =
     pytest {posargs}
 


### PR DESCRIPTION
### Overview

Updates the project’s test tooling and CI workflow to add explicit Django 5.2 test coverage via tox factors, alongside a patch version bump and changelog entry.

**Changes:**

- Expand tox envs to run tests against Django 4.2 and Django 5.2.
- Switch GitHub Actions CI to invoke tox (instead of installing deps + running pytest directly).
- Bump package version and add a changelog entry for the release.